### PR TITLE
add register function (fixes #61)

### DIFF
--- a/examples/sorting/cluster_beans.py
+++ b/examples/sorting/cluster_beans.py
@@ -27,19 +27,19 @@ hdf5file = os.path.join(os.sep, *path)
 io = components.PyTablesSource(hdf5file, dataset)
 io_filter = components.FilterStack()
 
-base.features.Provide("RawSource", io)
-base.features.Provide("EventsOutput", io)
-base.features.Provide("SignalSource", io_filter)
-base.features.Provide("SpikeMarkerSource",
+base.register("RawSource", io)
+base.register("EventsOutput", io)
+base.register("SignalSource", io_filter)
+base.register("SpikeMarkerSource",
                       components.SpikeDetector(contact=contact, 
                                                thresh=thresh,
                                                type=detection_type,
                                                sp_win=sp_win,
                                                resample=1,
                                                align=True))
-base.features.Provide("SpikeSource", components.SpikeExtractor(sp_win=sp_win))
-base.features.Provide("FeatureSource", components.FeatureExtractor())
-base.features.Provide("LabelSource", components.ClusterAnalyzer("gmm", 4))
+base.register("SpikeSource", components.SpikeExtractor(sp_win=sp_win))
+base.register("FeatureSource", components.FeatureExtractor())
+base.register("LabelSource", components.ClusterAnalyzer("gmm", 4))
 
 browser = components.SpikeBrowserWithLabels()
 feaute_plot = components.PlotFeaturesTimeline()

--- a/src/spike_beans/base.py
+++ b/src/spike_beans/base.py
@@ -29,9 +29,16 @@ class FeatureBroker(object):
             raise AttributeError("Unknown feature named %r" % feature)
         return provider()
 
+    def __setitem__(self, feature, component):
+        self.Provide(feature, component)
+
 
 features = FeatureBroker()
 
+def register(feature, component):
+    """register `component` as providing `feature`"""
+    features[feature]=component
+    return component
 ######################################################################
 ##
 ## Representation of Required Features and Feature Assertions

--- a/tests/test_beans.py
+++ b/tests/test_beans.py
@@ -98,4 +98,16 @@ def test_hasattribute_exceptions():
     data = comp.get_data()
     assert True
 
+@with_setup(setup, teardown)
+def test_register_new_feature_by_setitem():
+    base.features['Data']=DummyDataProvider()
+    comp = Dummy()
+    ok_(comp.get_data() == 'some data')
 
+@with_setup(setup, teardown)
+def test_register_new_feature_by_register():
+    dep_comp = DummyDataProvider()
+    added_comp = base.register("Data", dep_comp)
+    comp = Dummy()
+    ok_(comp.get_data() == 'some data')
+    assert dep_comp is added_comp


### PR DESCRIPTION
implements two new ways of registering features:
- via setting a mapping item `base.features['MyFeature'] = MyComponent()`
- via `register` function `my_comp = base.register('MyFeature', MyComponent())`
